### PR TITLE
Removing box-shadow to prevent overlapping of text and text shadow when ...

### DIFF
--- a/th-text.html
+++ b/th-text.html
@@ -23,13 +23,13 @@
 
       #container.background {
         background-color: {{background}}; /* Not supported in mobile */
-        box-shadow: 0.3em 0 0 {{background}}, -0.3em 0 0 {{background}}; /* Not supported in mobile */
       }
 
       #container.highlighting > * {
         line-height: 1.2;
         display: inline;
         background-color: {{highlighting}}; /* Not supported in mobile */
+        box-shadow: 0.2em 0 0 0 {{highlighting}}, -0.2em 0 0 0 {{highlighting}}; /* Not supported in mobile */
       }
 
       strong {
@@ -124,6 +124,7 @@
 
             for (var i=0; i<contentNodes.length; i++){
               contentNodes[i].style.backgroundColor = this.highlighting;
+              contentNodes[i].style.boxShadow = ".2em 0 0 0 0 "+this.highlighting+", -.2em 0 0 0 0 "+this.highlighting;
             }
             
           }
@@ -139,7 +140,6 @@
             // Inline styles for mobile version while Polymer does not support use of 
             // variables in style tags on mobile devices
             this.$.container.style.backgroundColor = this.background;
-            this.$.container.style.boxShadow = "0 0 0 0.2em "+this.background+",0 0 0 0.2em "+this.background;            
           }
 
         },


### PR DESCRIPTION
...the line-height is below 2.

With box-shadow and `line-height : 1.2;` : https://s3.amazonaws.com/uploads.hipchat.com/15499/204193/KbPopRm46JkgDLm/Screen%20Shot%202014-12-01%20at%203.36.11%20PM.png
